### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,10 +13,10 @@ Digimatic	KEYWORD1
 #######################################
 
 fetch	KEYWORD2
-units_mm KEYWORD2
-units_in KEYWORD2
-decimal_places KEYWORD2
-looptime KEYWORD2
+units_mm	KEYWORD2
+units_in	KEYWORD2
+decimal_places	KEYWORD2
+looptime	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords